### PR TITLE
Add OpenAPI annotations for configuration api chemas

### DIFF
--- a/modules/core/src/main/scala/api/AppRouter.scala
+++ b/modules/core/src/main/scala/api/AppRouter.scala
@@ -20,6 +20,8 @@ import sttp.tapir.swagger.*
 import sttp.tapir.swagger.bundle.*
 import endpoints.*
 import services.Services
+import sttp.apispec.Tag
+import sttp.apispec.ExternalDocumentation
 
 object AppRouter {
   def make(services: Services) = new AppRouter(services)
@@ -27,21 +29,20 @@ object AppRouter {
 
 class AppRouter(services: Services) {
 
-  val healthCheckEndpoints = new HealthCheckEndpoints().endpoints
-
-  val privacyRequestEndpoints    = new PrivacyRequestEndpoints(services.privacyRequest).endpoints
-  val consumerInterfaceEndpoints = new DataConsumerEndpoints(services.consumerInterface).endpoints
-  val configurationEndpoints     = new ConfigurationEndpoints(services.configuration).endpoints
-  val userEventsEndpoints        = new UserEventsEndpoints(services.userEvents).endpoints
-  val callbackEndpoints          = new CallbackEndpoints(services.callbacks).endpoints
+  val healthCheckEndpoints       = new HealthCheckEndpoints()
+  val privacyRequestEndpoints    = new PrivacyRequestEndpoints(services.privacyRequest)
+  val consumerInterfaceEndpoints = new DataConsumerEndpoints(services.consumerInterface)
+  val configurationEndpoints     = new ConfigurationEndpoints(services.configuration)
+  val userEventsEndpoints        = new UserEventsEndpoints(services.userEvents)
+  val callbackEndpoints          = new CallbackEndpoints(services.callbacks)
 
   val allEndpoints =
-    healthCheckEndpoints ++
-      privacyRequestEndpoints ++
-      consumerInterfaceEndpoints ++
-      configurationEndpoints ++
-      userEventsEndpoints ++
-      callbackEndpoints
+    healthCheckEndpoints.endpoints ++
+      privacyRequestEndpoints.endpoints ++
+      consumerInterfaceEndpoints.endpoints ++
+      configurationEndpoints.endpoints ++
+      userEventsEndpoints.endpoints ++
+      callbackEndpoints.endpoints
 
   // val docs: OpenAPI =
   //   OpenAPIDocsInterpreter()
@@ -53,8 +54,18 @@ class AppRouter(services: Services) {
 
   // println(docs.toYaml)
 
+  val tags = List(
+    Tag(
+      configurationEndpoints.Tag,
+      externalDocs = Some(ExternalDocumentation(configurationEndpoints.DocsUri, Some("docs")))
+    )
+  )
+
   val swagger =
-    SwaggerInterpreter(swaggerUIOptions = SwaggerUIOptions.default.pathPrefix(List("swagger")))
+    SwaggerInterpreter(
+      swaggerUIOptions = SwaggerUIOptions.default.pathPrefix(List("swagger")),
+      customiseDocsModel = _.tags(tags)
+    )
       .fromServerEndpoints[IO](
         allEndpoints,
         "Privacy computation engine",

--- a/modules/core/src/main/scala/api/endpoints/ConfigurationEndpoints.scala
+++ b/modules/core/src/main/scala/api/endpoints/ConfigurationEndpoints.scala
@@ -24,7 +24,10 @@ class ConfigurationEndpoints(
 ) {
   given Configuration = Configuration.default.withSnakeCaseMemberNames
 
-  val base = baseEndpoint.in("configure").tag("Configuration")
+  val Tag     = "Configuration"
+  val DocsUri = "https://blindnet.dev/docs/computation/configuration"
+
+  val base = baseEndpoint.in("configure").tag(Tag)
 
   val appId = UUID.fromString("6f083c15-4ada-4671-a6d1-c671bc9105dc")
 

--- a/modules/core/src/main/scala/api/messages/configuration/CreateLegalBasePayload.scala
+++ b/modules/core/src/main/scala/api/messages/configuration/CreateLegalBasePayload.scala
@@ -9,6 +9,7 @@ import io.blindnet.pce.util.parsing.*
 import io.circe.*
 import io.circe.generic.semiauto.*
 import io.circe.syntax.*
+import sttp.tapir.Schema.annotations.*
 import sttp.tapir.*
 import sttp.tapir.generic.Configuration
 import sttp.tapir.generic.auto.*
@@ -29,9 +30,19 @@ object ScopePayload {
 }
 
 case class CreateLegalBasePayload(
+    @description("type of the legal base")
+    @encodedExample("CONSENT")
     lbType: LegalBaseTerms,
+    @description("legal base name")
+    @encodedExample("Contact form")
     name: Option[String],
+    @description("legal base description")
+    @encodedExample("Collection of the contact data for advertising")
     description: Option[String],
+    @description("legal base description")
+    // format: off
+    @encodedExample(Set(ScopePayload(DataCategory("CONTACT"), ProcessingCategory("COLLECTION"), Purpose("ADVERTISING"))).asJson)
+    // format: on
     scope: Set[ScopePayload]
 ) {
   def getPrivPrivacyScope =

--- a/modules/core/src/main/scala/api/messages/configuration/CreateLegalBasePayload.scala
+++ b/modules/core/src/main/scala/api/messages/configuration/CreateLegalBasePayload.scala
@@ -39,7 +39,7 @@ case class CreateLegalBasePayload(
     @description("legal base description")
     @encodedExample("Collection of the contact data for advertising")
     description: Option[String],
-    @description("legal base description")
+    @description("privacy scope of the legal base")
     // format: off
     @encodedExample(Set(ScopePayload(DataCategory("CONTACT"), ProcessingCategory("COLLECTION"), Purpose("ADVERTISING"))).asJson)
     // format: on

--- a/modules/core/src/main/scala/api/messages/configuration/CreateProvenancePayload.scala
+++ b/modules/core/src/main/scala/api/messages/configuration/CreateProvenancePayload.scala
@@ -6,6 +6,7 @@ import io.blindnet.pce.util.parsing.*
 import io.circe.*
 import io.circe.generic.semiauto.*
 import io.circe.syntax.*
+import sttp.tapir.Schema.annotations.*
 import sttp.tapir.*
 import sttp.tapir.generic.Configuration
 import sttp.tapir.generic.auto.*
@@ -13,9 +14,16 @@ import priv.*
 import priv.privacyrequest.*
 import priv.terms.*
 
+@description("origin of the data category")
 case class CreateProvenancePayload(
+    @description("data category for which the provenance is created")
+    @encodedExample("CONTACT.PHONE")
     dataCategory: DataCategory,
+    @description("provenance type")
+    @encodedExample("USER")
     provenance: ProvenanceTerms,
+    @description("id of the system data category originated from. null for own system")
+    @encodedExample("https://blindnet.io")
     system: Option[String]
 )
 

--- a/modules/core/src/main/scala/api/messages/configuration/CreateRetentionPolicyPayload.scala
+++ b/modules/core/src/main/scala/api/messages/configuration/CreateRetentionPolicyPayload.scala
@@ -6,6 +6,7 @@ import io.blindnet.pce.util.parsing.*
 import io.circe.*
 import io.circe.generic.semiauto.*
 import io.circe.syntax.*
+import sttp.tapir.Schema.annotations.*
 import sttp.tapir.*
 import sttp.tapir.generic.Configuration
 import sttp.tapir.generic.auto.*
@@ -13,24 +14,30 @@ import priv.*
 import priv.privacyrequest.*
 import priv.terms.*
 
+@description("keep CONTACT for no longer than 30 days after a service defined by a legal base ends")
 case class CreateRetentionPolicyPayload(
+    @description("data category for which the policy is created")
+    @encodedExample("CONTACT")
     dataCategory: DataCategory,
+    @description("retention policy")
+    @encodedExample("NO-LONGER-THAN")
     policy: RetentionPolicyTerms,
+    @description("duration in JSON Schema duration format")
+    @encodedExample("P30D")
     duration: String,
+    @description("event type to which the retention duration is relative to")
+    @encodedExample("SERVICE-END")
     after: EventTerms
 )
 
 object CreateRetentionPolicyPayload {
-  given Decoder[CreateRetentionPolicyPayload] = unSnakeCaseIfy(
-    deriveDecoder[CreateRetentionPolicyPayload]
-  )
+  given Decoder[CreateRetentionPolicyPayload] =
+    unSnakeCaseIfy(deriveDecoder[CreateRetentionPolicyPayload])
 
-  given Encoder[CreateRetentionPolicyPayload] = snakeCaseIfy(
-    deriveEncoder[CreateRetentionPolicyPayload]
-  )
+  given Encoder[CreateRetentionPolicyPayload] =
+    snakeCaseIfy(deriveEncoder[CreateRetentionPolicyPayload])
 
-  given Schema[CreateRetentionPolicyPayload] = Schema.derived[CreateRetentionPolicyPayload](using
-    Configuration.default.withSnakeCaseMemberNames
-  )
+  given Schema[CreateRetentionPolicyPayload] = Schema
+    .derived[CreateRetentionPolicyPayload](using Configuration.default.withSnakeCaseMemberNames)
 
 }

--- a/modules/core/src/main/scala/api/messages/configuration/CreateSelectorPayload.scala
+++ b/modules/core/src/main/scala/api/messages/configuration/CreateSelectorPayload.scala
@@ -9,6 +9,7 @@ import io.blindnet.pce.util.parsing.*
 import io.circe.*
 import io.circe.generic.semiauto.*
 import io.circe.syntax.*
+import sttp.tapir.Schema.annotations.*
 import sttp.tapir.*
 import sttp.tapir.generic.Configuration
 import sttp.tapir.generic.auto.*
@@ -17,7 +18,11 @@ import priv.privacyrequest.*
 import priv.terms.*
 
 case class CreateSelectorPayload(
+    @description("selector name")
+    @encodedExample("HOME")
     name: String,
+    @description("selector is the subcategory of this data category")
+    @encodedExample("CONTACT.ADDRESS")
     dataCategory: DataCategory
 )
 


### PR DESCRIPTION
Add descriptions and example values for `CreateSelectorPayload`, `CreateLegalBasePayload`, `CreateRetentionPolicy` and `CreateProvenancePayload` schemas.