### PR TITLE
Add DAC authentication

### DIFF
--- a/modules/core/src/main/resources/db/migration/V0011__DAC_tokens.sql
+++ b/modules/core/src/main/resources/db/migration/V0011__DAC_tokens.sql
@@ -1,0 +1,2 @@
+alter table dac
+    add token text;

--- a/modules/core/src/main/scala/db/Migrator.scala
+++ b/modules/core/src/main/scala/db/Migrator.scala
@@ -15,12 +15,6 @@ object Migrator {
 
   private def migrate(flywayConf: FluentConfiguration) =
     for {
-      validation <- IO(flywayConf.load().validateWithResult())
-
-      _ <-
-        if validation.validationSuccessful then IO.unit
-        else IO.raiseError(MigrationError(validation.getAllErrorMessages()))
-
       res <- IO(flywayConf.load().migrate())
 
       _ <-

--- a/modules/core/src/main/scala/db/repositories/AppRepository.scala
+++ b/modules/core/src/main/scala/db/repositories/AppRepository.scala
@@ -24,7 +24,7 @@ object AppRepository {
 
       def get(id: UUID): IO[Option[PCEApp]] =
         sql"""
-          select a.id, d.active, d.uri, arc.auto_transparency, arc.auto_access, arc.auto_delete, arc.auto_consents
+          select a.id, d.active, d.uri, d.token, arc.auto_transparency, arc.auto_access, arc.auto_delete, arc.auto_consents
           from apps a
             join dac d on d.appid = a.id
             join automatic_responses_config arc on arc.appid = a.id

--- a/modules/core/src/main/scala/model/PCEApp.scala
+++ b/modules/core/src/main/scala/model/PCEApp.scala
@@ -9,7 +9,8 @@ import org.http4s.Uri
 
 case class DacConfig(
     usingDac: Boolean,
-    uri: Option[Uri]
+    uri: Option[Uri],
+    token: Option[String]
 )
 
 case class PCEApp(
@@ -20,12 +21,12 @@ case class PCEApp(
 
 object PCEApp {
   given Read[PCEApp] =
-    Read[(UUID, Boolean, Option[String], Boolean, Boolean, Boolean, Boolean)]
+    Read[(UUID, Boolean, Option[String], Option[String], Boolean, Boolean, Boolean, Boolean)]
       .map {
-        case (id, usingDac, dacUri, t, a, d, c) =>
+        case (id, usingDac, dacUri, dacToken, t, a, d, c) =>
           PCEApp(
             id,
-            DacConfig(usingDac, dacUri.map(Uri.unsafeFromString)),
+            DacConfig(usingDac, dacUri.map(Uri.unsafeFromString), dacToken),
             DemandResolutionStrategy.simple(t, a, d, c)
           )
       }

--- a/modules/core/src/main/scala/services/external/StorageInterface.scala
+++ b/modules/core/src/main/scala/services/external/StorageInterface.scala
@@ -67,17 +67,19 @@ object StorageInterface {
           callback = (conf.callbackUri / "callback" / callbackId.toString).toString
         )
 
-        def req(uri: Uri) = Request[IO](
+        def req(uri: Uri, token: String) = Request[IO](
           method = Method.POST,
-          uri = uri / "v1" / "requests"
+          uri = uri / "v1" / "requests",
+          headers = Headers("Authorization" -> s"Bearer $token")
         )
           .withEntity(payload)
 
         for {
           // TODO: exception
-          uri <- app.dac.uri.fold(IO.raiseError(new Exception("DAC uri not found")))(IO(_))
-          _   <- logger.info(s"Sending request to $uri \n ${payload.asJson}")
-          res <- c.successful(req(uri))
+          uri   <- app.dac.uri.fold(IO.raiseError(new Exception("DAC uri not found")))(IO(_))
+          token <- app.dac.token.fold(IO.raiseError(new Exception("DAC token not found")))(IO(_))
+          _     <- logger.info(s"Sending request to $uri \n ${payload.asJson}")
+          res   <- c.successful(req(uri, token))
           _ = if res then IO.unit else IO.raiseError(InternalException("Non 200 response from DAC"))
         } yield ()
       }
@@ -103,17 +105,19 @@ object StorageInterface {
           callback = (conf.callbackUri / "callback" / callbackId.toString).toString
         )
 
-        def req(uri: Uri) = Request[IO](
+        def req(uri: Uri, token: String) = Request[IO](
           method = Method.POST,
-          uri = uri / "v1" / "requests"
+          uri = uri / "v1" / "requests",
+          headers = Headers("Authorization" -> s"Bearer $token")
         )
           .withEntity(payload)
 
         for {
           // TODO: exception
-          uri <- app.dac.uri.fold(IO.raiseError(new Exception("DAC uri not found")))(IO(_))
-          _   <- logger.info(s"Sending request to $uri \n ${payload.asJson}")
-          res <- c.successful(req(uri))
+          uri   <- app.dac.uri.fold(IO.raiseError(new Exception("DAC uri not found")))(IO(_))
+          token <- app.dac.token.fold(IO.raiseError(new Exception("DAC token not found")))(IO(_))
+          _     <- logger.info(s"Sending request to $uri \n ${payload.asJson}")
+          res   <- c.successful(req(uri, token))
           _ = if res then IO.unit else IO.raiseError(InternalException("Non 200 response from DAC"))
         } yield ()
       }


### PR DESCRIPTION
Closes blindnet-io/product-management/issues/1011.

Adds a token field to the dac config in DB and uses it to authenticate requests.

I've added a fix to the `Migrator` class. Currently, it runs `validate` before `migrate` and therefore will fail if any new migration is available as it's not yet applied. Besides, Flyway already runs `validate` after `migrate` by default.